### PR TITLE
add feature to cache external api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "npm": "3.10.9"
   },
   "dependencies": {
+    "@angular-devkit/core": "^0.6.3",
     "@angular/animations": "^4.4.6",
     "@angular/cdk": "^2.0.0-beta.12",
-    "@angular/cli": "^1.5.0",
+    "@angular/cli": "^1.6.0-rc.2",
     "@angular/common": "^4.2.4",
     "@angular/compiler": "^4.2.4",
     "@angular/compiler-cli": "^4.2.4",
@@ -30,7 +31,7 @@
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
-    "@angular/service-worker": "1.0.0-beta.16",
+    "@angular/service-worker": "^1.0.0-beta.16",
     "core-js": "^2.4.1",
     "express": "^4.16.2",
     "rxjs": "^5.4.2",

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+PATH=$PATH:$(npm bin)
+set -x
+# Production build
+ng build --prod
+
+cd dist
+http-server

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import {FormsModule} from '@angular/forms';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MatButtonModule, MatSelectModule, MatInputModule, MatToolbarModule, MatCardModule} from '@angular/material';
 import {RouterModule} from '@angular/router';
-
+import {ServiceWorkerModule} from '@angular/service-worker';
 import {AppComponent} from './app.component';
 import {FoodService} from '../services/food.service';
 import {FoodItemComponent} from '../components/food-item/food-item.component';
@@ -15,6 +15,7 @@ import {AddRecipeComponent} from '../components/add-recipe/add-recipe.component'
 import {appRoutes} from './app.routes';
 import {SearchFoodComponent} from '../components/search-food/search-food.component';
 import { RoundPipe } from '../pipes/round.pipe';
+import { environment } from '../environments/environment';
 
 @NgModule({
   declarations: [
@@ -35,7 +36,7 @@ import { RoundPipe } from '../pipes/round.pipe';
     HttpModule,
     JsonpModule,
     BrowserAnimationsModule,
-    MatButtonModule, MatSelectModule, MatInputModule, MatToolbarModule, MatCardModule
+    MatButtonModule, MatSelectModule, MatInputModule, MatToolbarModule, MatCardModule,ServiceWorkerModule
   ],
   providers: [FoodService,RecipeService],
   bootstrap: [AppComponent]

--- a/src/ngsw-manifest.json
+++ b/src/ngsw-manifest.json
@@ -1,20 +1,23 @@
 {
-  "static": {
-    "urls": {
-      "/polyfills.22634ea7c96a7dd2a02a.bundle.js": "c9f09ee17bf698424ae5718ee095186f79068671",
-      "/main.2016aaf2d72bf7c02ea0.bundle.js": "b3fae682c9ac4d9707b002f6bb0f0eb3f5f6aa04",
-      "/sw-register.6819cd2c5fa25470ecf2.bundle.js": "50d549edfbd188ed199d8d0b079afa593202e3ea",
-      "/vendor.63934d119086415531a1.bundle.js": "5792d9cb442fb50693173069df75394f2ea508d4",
-      "/inline.d0262e2c17b3d49979f8.bundle.js": "2b5821fcb544e8749b33d59e521419339b49f8ff",
-      "/styles.b0e45babab63a7b5f37d.bundle.css": "4f9aa3048ee7e6d926fa518829788ddff4b01db9",
-      "/favicon.ico": "8c21e78ac637dfaecf505ff1d6499cee3914261b",
-      "/index.html": "25f37e6822d6c364679813c3f34c7407dfd6f54e"
-    },
-    "external": {
+  "dynamic": {
+    "group": [{
+      "name": "indian food facts",
       "urls": {
-        "url": "https://fonts.googleapis.com/css?family=Roboto"
+         "https://indianfoodfacts-api.herokuapp.com/api/food/": {
+           "match": "prefix"
+         }
+      },
+      "cache": { 
+        "optimizeFor": "performance",  
+        "maxAgeMs": 3600000,  
+        "maxEntries": 20,     
+        "strategy": "lru"
       }
-    },
-    "_generatedFromWebpack": true
+    }]
+  },
+  "external": {
+    "urls": [{
+      "url": "https://fonts.googleapis.com/css?family=Roboto"
+    }]
   }
 }


### PR DESCRIPTION
## What did you implement:

I have implemented cache first approach in search results. As of now any search results will be cached by service worker and then served from cache for the same request. LRU strategy has been used for the same. This will enable application to serve requests even if the server is offline/no internet.

## How can we verify it:

Steps to Verify:
 1. Run the application in production mode or use command sh run.sh
 2. Search for few items
3. Now run the app in offline mode
4. Results should appear for any item that has been searched already. 